### PR TITLE
chore: use reusable workflows, pin actions

### DIFF
--- a/.github/workflows/adocs-build-develop.yml
+++ b/.github/workflows/adocs-build-develop.yml
@@ -2,47 +2,26 @@ name: build adocs and publish to Github-pages
 
 permissions:
   contents: write
-  pages: write
 
 on:
   push:
     branches:
-    - develop
+      - develop
     paths:
-    - docs/**
+      - docs/**
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-    steps:
-
-    - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      with:
-          submodules: true
-          fetch-depth: 0
-
-    - name: Update submodules to latest main
-      run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-    - name: Build html
-      id: adocbuild_html
-      uses: Analog-inc/asciidoctor-action@master
-      with:
-          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-    - name: Build pdf
-      id: adocbuild_pdf
-      uses: Analog-inc/asciidoctor-action@master
-      with:
-          shellcommand: "asciidoctor-pdf -D docs -o files/hvd-dcat-ap-no.pdf -a lang=nb docs/main.adoc"
-      continue-on-error: true
-
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs
+  build-adocs:
+    name: Build and deploy to GitHub Pages
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-github-pages.yaml@main
+    with:
+      ref: develop
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/hvd-dcat-ap-no.pdf -a lang=nb docs/main.adoc
+      program_pdf_continue_on_error: true
+      publish_branch: gh-pages
+      publish_dir: ./docs
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-v1-to-production.yml
+++ b/.github/workflows/publish-v1-to-production.yml
@@ -12,54 +12,28 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-    permissions:
-      contents: read
-      security-events: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          ref: v1
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild_html
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-          shellcommand: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: Analog-inc/asciidoctor-action@master
-        with:
-            shellcommand: "asciidoctor-pdf -D docs -o files/hvd-dcat-ap-no.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Upload files to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@84beeeacd364f310ef6a253bc079354cdf62e5dd
-        id: upload-files
-        with:
-          ontology-type: "specification"
-          ontology: "hvd-dcat-ap-no"
-          host: "https://data.norge.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            docs/index.html text/html nb
-            docs/files/hvd-dcat-ap-no.pdf application/pdf nb files/hvd-dcat-ap-no.pdf
-            docs/images/Digdir.png image/png nb images/Digdir.png
-            docs/images/datasett-distribusjon-datatjeneste.png image/png nb images/datasett-distribusjon-datatjeneste.png
-            docs/images/HVD-DCAT-AP-NO-forenklet-fremstilling.png image/png nb images/HVD-DCAT-AP-NO-forenklet-fremstilling.png
-            docs/images/Klassen-Datasett.png image/png nb images/Klassen-Datasett.png
-            docs/images/Klassen-Datasettserie.png image/png nb images/Klassen-Datasettserie.png
-            docs/images/Klassen-Datatjeneste.png image/png nb images/Klassen-Datatjeneste.png
-            docs/images/Klassen-Distribusjon.png image/png nb images/Klassen-Distribusjon.png
+  upload-files-to-production:
+    name: Upload specification to static-rdf-server
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v1
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/hvd-dcat-ap-no.pdf -a lang=nb docs/main.adoc
+      program_pdf_continue_on_error: true
+      files: |
+        docs/index.html text/html nb
+        docs/files/hvd-dcat-ap-no.pdf application/pdf nb files/hvd-dcat-ap-no.pdf
+        docs/images/Digdir.png image/png nb images/Digdir.png
+        docs/images/datasett-distribusjon-datatjeneste.png image/png nb images/datasett-distribusjon-datatjeneste.png
+        docs/images/HVD-DCAT-AP-NO-forenklet-fremstilling.png image/png nb images/HVD-DCAT-AP-NO-forenklet-fremstilling.png
+        docs/images/Klassen-Datasett.png image/png nb images/Klassen-Datasett.png
+        docs/images/Klassen-Datasettserie.png image/png nb images/Klassen-Datasettserie.png
+        docs/images/Klassen-Datatjeneste.png image/png nb images/Klassen-Datatjeneste.png
+        docs/images/Klassen-Distribusjon.png image/png nb images/Klassen-Distribusjon.png
+      host: https://data.norge.no
+      ontology: hvd-dcat-ap-no
+      ontology-type: specification
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}


### PR DESCRIPTION
# Summary
Migrate both spec workflows to the central Informasjonsforvaltning/workflows reusable workflows, resolving #33 by pinning all GitHub Actions to commit SHAs.

- Migrate `adocs-build-develop.yml` to call `specification-github-pages.yaml@main`
- Migrate `publish-v1-to-production.yml` to call `specification-upload-files.yaml@main`
- Removes all 8 unpinned action references; pinning now handled centrally
- Drops unused `pages: write` / `security-events: write` permissions

Closes #33